### PR TITLE
build(mentor): Pin danger-js to 6.0.0 to resolve markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "codeclimate-test-reporter": "^0.5.0",
     "commitizen": "^3.0.5",
     "cz-conventional-changelog": "^2.0.0",
-    "danger": "6.1.7",
+    "danger": "6.0.0",
     "danger-plugin-mentor": "^0.8.0",
     "danger-plugin-yarn": "^1.2.1",
     "husky": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,9 +1893,10 @@ danger-plugin-yarn@^1.2.1:
   optionalDependencies:
     esdoc "^0.5.2"
 
-danger@6.1.7:
-  version "6.1.7"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-6.1.7.tgz#c74bdcd266fb32e418b2cb64c3b01a0fe035429f"
+danger@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-6.0.0.tgz#f18d48508162e092f092fce9bad1b252622a4337"
+  integrity sha512-H8Caf3fxFMEZfTflOGv+z8afZiqg6+teQVrdd+ksovaCECCm/aaAOb9kVawwt0YgK/EQFUvxbaVLpECIfsuEPw==
   dependencies:
     "@babel/polyfill" "^7.0.0"
     "@octokit/rest" "^15.12.1"


### PR DESCRIPTION
Does this change anything?