### PR TITLE
build(mentor): Only run danger on PRs from origin itself.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 script:
   - yarn test -- --coverage
   - yarn run lint
-  - yarn danger ci
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash -c "yarn danger ci"; fi'
 after_script:
   - greenkeeper-lockfile-upload
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT


### PR DESCRIPTION
Travis CI doesn't expose secure env vars to forks, makes sense.
https://docs.travis-ci.com/user/pull-requests/