### PR TITLE
build(mentor): Drop node 8 and 11, add node 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ cache:
 notifications:
   email: false
 node_js:
+  - '13'
   - '12'
-  - '11'
   - '10'
-  - '8'
 before_install: yarn global add greenkeeper-lockfile@1
 before_script:
   - greenkeeper-lockfile-update


### PR DESCRIPTION
BREAKING CHANGE: As node 8 and 11 are out of maintenance now
(or will be in a few days), this is potentially a breaking change.
Realistically, there is no reason it shouldn't continue to work.